### PR TITLE
Fixes for ASIO >= 1.13 + fixed assertion when parsing SOCKS v header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+boost_logs/
+shinkysocks_*.log

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "thread": "cpp"
+    }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 project(shinysocks)
 
 
 set(Boost_USE_MULTITHREADED ON)
-if (UNIX)
+
 find_package(Boost REQUIRED COMPONENTS
     system
     program_options
@@ -18,13 +18,22 @@ find_package(Boost REQUIRED COMPONENTS
     log
     thread
     )
-endif()
 
 if (WIN32)
-	include_directories(${BOOST_ROOT})
-	message(STATUS "Boost root: ${BOOST_ROOT}")
-	link_directories(${BOOST_LIBRARYDIR})
-	add_definitions(-D_WIN32_WINNT=0x0600)
+    set(LIB_BOOST_PROGRAM_OPTIONS Boost::program_options)
+    set(LIB_BOOST_SERIALIZATION Boost::serialization)
+    set(LIB_BOOST_FILESYSTEM Boost::filesystem)
+    set(LIB_BOOST_DATE_TIME Boost::date_time)
+    set(LIB_BOOST_IOSTREAMS Boost::iostreams)
+    set(LIB_BOOST_SYSTEM Boost::system)
+    set(LIB_BOOST_REGEX Boost::regex)
+    set(LIB_BOOST_CONTEXT Boost::context)
+    set(LIB_BOOST_COROUTINE Boost::coroutine)
+    set(LIB_BOOST_CHRONO Boost::chrono)
+    set(LIB_BOOST_THREAD Boost::thread)
+    set(LIB_BOOST_LOG Boost::log Boost::log_setup)
+    set(BOOST_UNIT_TEST_FRAMEWORK Boost::unit_test_framework)
+    add_definitions(-D_WIN32_WINNT=0x0600)
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")
     # Msvc and possible some other Windows-compilers will link
     # to the correct libraries trough #pragma directives in boost headers.
@@ -45,22 +54,20 @@ else ()
     SET(BOOST_UNIT_TEST_FRAMEWORK boost_unit_test_framework)
 endif ()
 
-if (UNIX)
-    set (BOOST_LIBRARIES
-        ${LIB_BOOST_SYSTEM}
-        ${LIB_BOOST_PROGRAM_OPTIONS}
-        ${LIB_BOOST_SERIALIZATION}
-        ${LIB_BOOST_FILESYSTEM}
-        ${LIB_BOOST_DATE_TIME}
-        ${LIB_BOOST_IOSTREAMS}
-        ${LIB_BOOST_REGEX}
-        ${LIB_BOOST_CONTEXT}
-        ${LIB_BOOST_COROUTINE}
-        ${LIB_BOOST_CHRONO}
-        ${LIB_BOOST_LOG}
-        ${LIB_BOOST_THREAD}
-    )
-endif()
+set (BOOST_LIBRARIES
+    ${LIB_BOOST_SYSTEM}
+    ${LIB_BOOST_PROGRAM_OPTIONS}
+    ${LIB_BOOST_SERIALIZATION}
+    ${LIB_BOOST_FILESYSTEM}
+    ${LIB_BOOST_DATE_TIME}
+    ${LIB_BOOST_IOSTREAMS}
+    ${LIB_BOOST_REGEX}
+    ${LIB_BOOST_CONTEXT}
+    ${LIB_BOOST_COROUTINE}
+    ${LIB_BOOST_CHRONO}
+    ${LIB_BOOST_LOG}
+    ${LIB_BOOST_THREAD}
+)
 
 if (UNIX)
     set(THREADLIBS pthread)
@@ -77,7 +84,12 @@ endif()
 add_executable(shinysocks Manager.cpp Listener.cpp Proxy.cpp main.cpp)
 target_compile_definitions(shinysocks PUBLIC -DBOOST_COROUTINE_NO_DEPRECATION_WARNING=1)
 target_compile_definitions(shinysocks PUBLIC -DBOOST_COROUTINES_NO_DEPRECATION_WARNING=1)
-target_link_libraries(shinysocks ${BOOST_LIBRARIES} ${THREADLIBS})
+
+if (UNIX)
+    target_link_libraries(shinysocks ${BOOST_LIBRARIES} ${THREADLIBS})
+elseif (WIN32)
+    target_link_libraries(shinysocks PRIVATE Boost::boost ${BOOST_LIBRARIES})
+endif()
 
 
 install(TARGETS shinysocks RUNTIME DESTINATION bin)

--- a/Listener.cpp
+++ b/Listener.cpp
@@ -39,7 +39,7 @@ void Listener::StartAcceptingInt(boost::asio::io_service& ios,
 
             BOOST_LOG_TRIVIAL(info) << "Incoming connection on socket.";
 
-            auto& ios = socket.get_io_service();
+            auto& ios = socket.get_executor();
             auto proxy = make_shared<Proxy>(move(socket));
             boost::asio::spawn(ios,
                                bind(&Proxy::Run,

--- a/Proxy.cpp
+++ b/Proxy.cpp
@@ -10,7 +10,7 @@ using boost::asio::ip::tcp;
 namespace shinysocks {
 
 Proxy::Proxy(tcp::socket&& sck)
-: client_(move(sck)), server_(client_.get_io_service())
+: client_(move(sck)), server_(client_.get_executor())
 {
 }
 
@@ -103,7 +103,7 @@ void Proxy::RunInt(boost::asio::yield_context& yield) {
 
 
     // Forward traffic from server to client
-    boost::asio::spawn(client_.get_io_service(),
+    boost::asio::spawn(client_.get_executor(),
                         bind(&Proxy::RelayRoot,
                             shared_from_this(),
                             ref(server_), ref(client_),
@@ -171,7 +171,7 @@ void Proxy::ParseV4Header(const char *buffer,
         const string host(host_start, host_end);
         BOOST_LOG_TRIVIAL(info) << "Will try to connect to: " << host;
 
-        tcp::resolver resolver(client_.get_io_service());
+        tcp::resolver resolver(client_.get_executor());
         auto address_it = resolver.async_resolve({host, to_string(port_)},
                                                     yield);
         decltype(address_it) addr_end;
@@ -313,7 +313,7 @@ again:
                     BOOST_LOG_TRIVIAL(info)
                         << "ParseV5Header: Will try to connect to: " << hostname;
 
-                    tcp::resolver resolver(client_.get_io_service());
+                    tcp::resolver resolver(client_.get_executor());
                     auto address_it = resolver.async_resolve({hostname, to_string(port_)},
                                                              yield);
                     decltype(address_it) addr_end;

--- a/Proxy.cpp
+++ b/Proxy.cpp
@@ -228,9 +228,12 @@ void Proxy::ParseV5Header(const char *buffer,
     vector<char> hdr_buffer;
     {
         const size_t remaining = len - header_len;
-        hdr_buffer.reserve(1024);
-        hdr_buffer.resize(remaining);
-        memcpy(&hdr_buffer[0], buffer + header_len, remaining);
+        if (remaining > 0)
+        {
+            hdr_buffer.reserve(1024);
+            hdr_buffer.resize(remaining);
+            memcpy(&hdr_buffer[0], buffer + header_len, remaining);
+        }
     }
 
     bool need_more_data = hdr_buffer.size() < 7;

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,1 @@
+cmake -G "Visual Studio 17 2022" -A x64 .. -DCMAKE_TOOLCHAIN_FILE=C:/progo/alien/vcpkg/scripts/buildsystems/vcpkg.cmake

--- a/shinysocks.ps1
+++ b/shinysocks.ps1
@@ -1,0 +1,6 @@
+
+Start-Process .\build\RelWithDebInfo\shinysocks.exe -NoNewWindow
+
+Start-Sleep -Seconds 2
+
+Get-Content -Path .\shinysocks_*.log -Tail 300 -Wait


### PR DESCRIPTION
Recent versions of ASIO (I am using Boost 1.77) have removed the `get_io_service()` method. The `get_executor()` method can be used instead.

Also, in some cases, in `Proxy::ParseV5Header`, when copying parts of `buffer` to `hdr_buffer`, the `remaining` size was 0 and the C debug runtime complained because we took the address of the first element of the empty buffer (`&hdr_buffer[0]`)

The first change is risky because it bumps the version requirement on ASIO, while the second change looks harmless.